### PR TITLE
Fixes #20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volcano-cooking"
-version = "0.5.3"
+version = "0.5.4"
 description = "Make some volcanoes and simulate them in CESM2"
 authors = ["engeir <eirroleng@gmail.com>"]
 license = "GPL-3.0"

--- a/src/volcano_cooking/__init__.py
+++ b/src/volcano_cooking/__init__.py
@@ -1,2 +1,2 @@
 # src/volcano_cooking/__init__.py
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/src/volcano_cooking/modules/convert/adjust_emissions_and_heights.py
+++ b/src/volcano_cooking/modules/convert/adjust_emissions_and_heights.py
@@ -43,7 +43,8 @@ def adjust_altitude_range(
     threshold = 3.5  # Tg
     idx = (tes > threshold) & (mxihs > 20)
     mxihs[idx] = 20
-    miihs[miihs[idx] > 18] = 18
+    # If some of the lower boundaries at `idx` are higher than 18, we set them to 18.
+    miihs[idx & (miihs > 18)] = 18
     return miihs, mxihs
 
 


### PR DESCRIPTION
Fixes #20

When trying to re-set the heights of the minimum injections heights
array that correspond to the maximum injection height array that had
been changed, it was mistakenly cropped when also checking which was
greater than a constant value. The two comparisons must be done in one
comparison, not one first then the second.