### PR TITLE
Fix bug when no events are present in chosen time span

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volcano-cooking"
-version = "0.5.7"
+version = "0.5.8"
 description = "Make some volcanoes and simulate them in CESM2"
 authors = ["engeir <eirroleng@gmail.com>"]
 license = "GPL-3.0"

--- a/src/volcano_cooking/__init__.py
+++ b/src/volcano_cooking/__init__.py
@@ -1,2 +1,2 @@
 # src/volcano_cooking/__init__.py
-__version__ = "0.5.7"
+__version__ = "0.5.8"

--- a/src/volcano_cooking/sparse_to_lin.py
+++ b/src/volcano_cooking/sparse_to_lin.py
@@ -74,6 +74,8 @@ def sparse_to_lin(
     mask = abs(t[None, :] - t_i[:, None]).argmin(axis=0)
     _, mask_idx = np.unique(mask, return_index=True)
     mask_sections = [mask[m : mask_idx[i + 1]] for i, m in enumerate(mask_idx[:-1])]
+    if len(mask_sections) == 0:
+        return t_i, [], []
     mask_sections.append(mask[mask_idx[-1] :])
     # Now we find the indices of `t` that we want to keep. `c` works as the index of the
     # first item in each array inside mask_sections


### PR DESCRIPTION
This commit fixes #26, which reported an issue when an array is sent in
to the function `sparse_to_lin` that did not have any events in the
region where the function was asked to interpolate.

The new behaviour is to return empty lists, i.e., no masking, along with
the linspace time axis.