### PR TITLE
Set lat, lon and min, max injection height from json file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volcano-cooking"
-version = "0.8.0"
+version = "0.9.0"
 description = "Make some volcanoes and simulate them in CESM2"
 authors = ["engeir <eirroleng@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/src/volcano_cooking/__init__.py
+++ b/src/volcano_cooking/__init__.py
@@ -1,2 +1,2 @@
 # src/volcano_cooking/__init__.py
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/volcano_cooking/modules/create/rewrite_frc_file.py
+++ b/src/volcano_cooking/modules/create/rewrite_frc_file.py
@@ -40,11 +40,11 @@ class ReWrite(Data):
             "originals",
             "VolcanEESMv3.11_SO2_850-2016_Mscale_Zreduc_2deg_c191125",
         )
-        if not os.path.exists(file + ".nc"):
+        if not os.path.exists(f"{file}.nc"):
             raise FileNotFoundError(
                 f"{file} not found. Consult README on how to download."
             )
-        f_orig = xr.open_dataset(file + ".nc", decode_times=False)
+        f_orig = xr.open_dataset(f"{file}.nc", decode_times=False)
         # Check that the file contain crucial data.
         needed_dims = ["time", "altitude", "lat", "lon"]
         if any(d not in f_orig.dims for d in needed_dims):
@@ -125,7 +125,7 @@ class ReWrite(Data):
             # way, all meta data is also used in the new Dataset as in the old, which is
             # needed.
             if v == "stratvolc":
-                input = xr.DataArray(
+                the_input = xr.DataArray(
                     new_eruptions,
                     dims=["time", "altitude", "lat", "lon"],
                     coords={
@@ -135,15 +135,15 @@ class ReWrite(Data):
                     },
                 )
             elif v == "date":
-                input = xr.DataArray(new_dates.astype(np.int32), dims="time")
+                the_input = xr.DataArray(new_dates.astype(np.int32), dims="time")
             elif v == "datesec":
-                input = xr.DataArray(new_datesecs.astype(np.int32), dims="time")
+                the_input = xr.DataArray(new_datesecs.astype(np.int32), dims="time")
             else:
                 raise IndexError(
                     f"'{v}' is an unknown variable that I do not have an implementation for."
                 )
-            input = input.assign_attrs(**f_orig[v].attrs)
-            self.my_frc = self.my_frc.assign({v: input})
+            the_input = the_input.assign_attrs(**f_orig[v].attrs)
+            self.my_frc = self.my_frc.assign({v: the_input})
 
         # helper_scripts.compare_datasets(self.my_frc, f_orig)
 
@@ -171,10 +171,10 @@ class ReWrite(Data):
             elif a == "data_source_files":
                 self.my_frc.attrs[a] = "https://github.com/engeir/volcano-cooking"
             elif a == "creation_date":
-                if datetime.today().strftime("%Z"):
-                    this_day = datetime.today().strftime("%a %b %d %X %Z %Y")
+                if datetime.now().strftime("%Z"):
+                    this_day = datetime.now().strftime("%a %b %d %X %Z %Y")
                 else:
-                    this_day = datetime.today().strftime("%a %b %d %X %Y")
+                    this_day = datetime.now().strftime("%a %b %d %X %Y")
                 self.my_frc.attrs[a] = this_day
             elif a == "cesm_contact":
                 self.my_frc.attrs[a] = "None"
@@ -199,7 +199,7 @@ class ReWrite(Data):
                     d_ = "0" * (w_1 - len(str(int(d)))) + str(int(d)) + " "
                     amin_ = f"{amin:.3f}".rjust(w_23) + " "
                     amax_ = f"{amax:.3f}".rjust(w_23) + " "
-                    v_ = str(v).center(w_4) + " "
+                    v_ = f"{str(v).center(w_4)} "
                     e_ = f"{e:.5e}".rjust(w_5)
                     nl = d_ + amin_ + amax_ + v_ + e_ + "\n"
                     summary += nl

--- a/tests/test_create_data.py
+++ b/tests/test_create_data.py
@@ -2,6 +2,7 @@
 import inspect
 import json
 
+import numpy as np
 import pytest
 from click.testing import CliRunner
 
@@ -33,3 +34,57 @@ def test_generate_classes(runner: CliRunner) -> None:
                 assert issubclass(c, cr.Generate)
                 c_.generate()
                 cr.Data(*c_.get_arrays())
+
+
+def test_generate_from_file(runner: CliRunner) -> None:
+    """Test the json file input."""
+    d1 = {"dates": ["1850-01-17"], "emissions": ["400", "400"]}
+    d2 = {"emissions": ["400", "400"]}
+    d3 = {
+        "dates": ["1850-01-17", "1860-01-01"],
+        "emissions": ["400", "400"],
+        "lat": ["0.0", "20.0"],
+        "lon": ["120.0", "0.0"],
+        "minimum injection height": ["25", "27"],
+        "maximum injection height": ["26", "26"],
+    }
+    with runner.isolated_filesystem():
+        with open("new_file.json", "w") as f:
+            json.dump(d1, f, indent=2)
+        module_ = "volcano_cooking.modules.create.create_data"
+        for n, c in inspect.getmembers(cr, inspect.isclass):
+            if c.__module__ == module_ and n in ["GenerateFromFile"]:
+                c_ = c(20, 20, "new_file.json")
+                assert issubclass(c, cr.Generate)
+                with pytest.raises(KeyError):
+                    c_.generate()
+    with runner.isolated_filesystem():
+        with open("new_file.json", "w") as f:
+            json.dump(d2, f, indent=2)
+        module_ = "volcano_cooking.modules.create.create_data"
+        for n, c in inspect.getmembers(cr, inspect.isclass):
+            if c.__module__ == module_ and n in ["GenerateFromFile"]:
+                c_ = c(20, 20, "new_file.json")
+                assert issubclass(c, cr.Generate)
+                with pytest.raises(KeyError):
+                    c_.generate()
+    with runner.isolated_filesystem():
+        with open("new_file.json", "w") as f:
+            json.dump(d3, f, indent=2)
+        module_ = "volcano_cooking.modules.create.create_data"
+        for n, c in inspect.getmembers(cr, inspect.isclass):
+            if c.__module__ == module_ and n in ["GenerateFromFile"]:
+                c_ = c(20, 20, "new_file.json")
+                assert issubclass(c, cr.Generate)
+                c_.generate()
+                ds = cr.Data(*c_.get_arrays())
+                assert np.array_equal(ds.lats, np.array(d3["lat"], dtype=np.float32))
+                assert np.array_equal(ds.lons, np.array(d3["lon"], dtype=np.float32))
+                assert np.array_equal(ds.miihs, np.array([25, 26], dtype=np.float32))
+                assert np.array_equal(ds.mxihs, np.array([26, 27], dtype=np.float32))
+                assert np.array_equal(
+                    ds.tes, np.array(d3["emissions"], dtype=np.float32)
+                )
+                assert np.array_equal(ds.yoes, np.array([1850, 1860], dtype=np.int16))
+                assert np.array_equal(ds.moes, np.array([1, 1], dtype=np.float32))
+                assert np.array_equal(ds.does, np.array([17, 1], dtype=np.float32))


### PR DESCRIPTION
This PR opens up for the possibility of setting latitude, longitude, minimum injection height and maximum injection height from a json file. Previously, only dates and emissions was supported.

This also introduces one method that sets lat, lon, and one method that sets min, max injections heights, which makes making new Generate classes more flexible.